### PR TITLE
fix: MiddyMiddleware's log("baselime") => log("info")

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,12 +162,12 @@ function wrap(func) {
 function MiddyMiddleware() {
 	return {
 		before: ({ event }) => {
-			log("baselime", "baselime:trigger", {
+			log("info", "baselime:trigger", {
 				event: decodeEventBody(event),
 			});
 		},
 		after: ({ response }) => {
-			log("baselime", "baselime:response", {
+			log("info", "baselime:response", {
 				response,
 			});
 		},


### PR DESCRIPTION
Prevents the following error from being thrown:

```
Aug 28, 01:23:35 UTC

START RequestId: 351b9d4f-e276-4068-ad2d-14fa692ddd2a Version: $LATEST
Aug 28, 01:23:35 UTC

2023-08-28T01:23:35.094Z 351b9d4f-e276-4068-ad2d-14fa692ddd2a ERROR level baselime is not a function
Aug 28, 01:23:35 UTC

2023-08-28T01:23:35.095Z 351b9d4f-e276-4068-ad2d-14fa692ddd2a ERROR
TypeError: console[level] is not a function
    at log (file:///var/task/services/functions/http-app/health-check.mjs:16132:23)
    at before (file:///var/task/services/functions/http-app/health-check.mjs:16187:11)
    at runMiddlewares (file:///var/task/services/functions/http-app/health-check.mjs:17167:23)
    at async runRequest (file:///var/task/services/functions/http-app/health-check.mjs:17125:5)
```